### PR TITLE
新增會員登入與訂閱管理功能

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -58,7 +58,8 @@ Prisma schema 位於 `app/prisma/schema.prisma`，`server/routes/` 目前為空�
 3. 設定環境變數 `.env`：
    ```env
    DATABASE_URL=postgres://user:password@localhost:5432/db_name
-   STRIPE_KEY=your_stripe_secret
+   STRIPE_SECRET_KEY=your_stripe_secret
+   JWT_SECRET=your_jwt_secret
    ```
 4. 建立資料庫與執行遷移（若有使用 ORM，如 Prisma）：
    ```bash
@@ -86,6 +87,7 @@ Prisma schema 位於 `app/prisma/schema.prisma`，`server/routes/` 目前為空�
 2. 使用者以行動裝置掃描 NFC 後，進入對應的 Nuxt 網頁。
 3. 在頁面上留下好評或透過 Stripe 完成付款流程。
 4. 後台可查看累積的好評與交易紀錄。
+5. 會員登入後可於 Dashboard 檢視訂閱狀態並隨時取消。
 
 ## 開發者注意事項
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,2 +1,4 @@
 DATABASE_URL="file:./dev.db"
+STRIPE_SECRET_KEY="sk_test_your_key"
+JWT_SECRET="your_jwt_secret"
 

--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -1,0 +1,6 @@
+export default defineNuxtRouteMiddleware(async () => {
+  const { data } = await useFetch('/api/user')
+  if (!data.value || !(data.value as any).id) {
+    return navigateTo('/login')
+  }
+})

--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -4,5 +4,8 @@ export default defineNuxtConfig({
   modules: ['@nuxtjs/tailwindcss'],
   typescript: {
     strict: true
+  },
+  alias: {
+    '#utils': './server/utils'
   }
 })

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,10 @@
     "nuxt": "^3.10.3",
     "@nuxtjs/tailwindcss": "^6.8.0",
     "tailwindcss": "^3.3.5",
-    "@prisma/client": "^5.2.0"
+    "@prisma/client": "^5.2.0",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.1",
+    "stripe": "^12.17.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="p-4">
+    <h1 class="text-xl font-bold mb-4">會員儀表板</h1>
+    <div v-if="pending">載入中...</div>
+    <div v-else>
+      <p>訂閱狀態：{{ status || '無' }}</p>
+      <button v-if="status && status !== 'canceled'" @click="cancel" class="mt-4 px-4 py-2 bg-red-500 text-white">取消訂閱</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ middleware: 'auth' })
+
+const { data, pending, refresh } = await useFetch('/api/subscription')
+const status = computed(() => data.value?.status)
+
+const cancel = async () => {
+  await $fetch('/api/subscription/cancel', { method: 'POST' })
+  await refresh()
+}
+</script>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,5 +2,10 @@
   <div class="p-8 text-center">
     <h1 class="text-2xl font-bold">Nuxt 3 範例專案</h1>
     <p class="mt-4 text-gray-600">Tailwind CSS 已載入成功</p>
+    <div class="mt-6 space-x-4">
+      <NuxtLink to="/login" class="text-blue-600">登入</NuxtLink>
+      <NuxtLink to="/register" class="text-blue-600">註冊</NuxtLink>
+      <NuxtLink to="/dashboard" class="text-blue-600">Dashboard</NuxtLink>
+    </div>
   </div>
 </template>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="max-w-md mx-auto p-4">
+    <h1 class="text-xl font-bold mb-4">會員登入</h1>
+    <form @submit.prevent="onSubmit" class="space-y-4">
+      <input v-model="email" type="email" placeholder="Email" class="w-full border p-2" />
+      <input v-model="password" type="password" placeholder="Password" class="w-full border p-2" />
+      <button type="submit" class="px-4 py-2 bg-blue-500 text-white">登入</button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+const email = ref('')
+const password = ref('')
+
+const onSubmit = async () => {
+  await $fetch('/api/login', { method: 'POST', body: { email: email.value, password: password.value } })
+  await navigateTo('/dashboard')
+}
+</script>

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="max-w-md mx-auto p-4">
+    <h1 class="text-xl font-bold mb-4">會員註冊</h1>
+    <form @submit.prevent="onSubmit" class="space-y-4">
+      <input v-model="email" type="email" placeholder="Email" class="w-full border p-2" />
+      <input v-model="password" type="password" placeholder="Password" class="w-full border p-2" />
+      <button type="submit" class="px-4 py-2 bg-blue-500 text-white">註冊</button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+const email = ref('')
+const password = ref('')
+
+const onSubmit = async () => {
+  await $fetch('/api/register', { method: 'POST', body: { email: email.value, password: password.value } })
+  await navigateTo('/dashboard')
+}
+</script>

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -13,3 +13,14 @@ model Example {
   id   Int    @id @default(autoincrement())
   name String
 }
+
+model User {
+  id                 Int      @id @default(autoincrement())
+  email              String   @unique
+  password           String
+  stripeCustomerId   String?  @map("stripe_customer_id")
+  subscriptionId     String?  @map("subscription_id")
+  subscriptionStatus String?  @map("subscription_status")
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+}

--- a/app/server/api/login.post.ts
+++ b/app/server/api/login.post.ts
@@ -1,0 +1,26 @@
+import { prisma } from '#utils/prisma'
+import { createError } from 'h3'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { email, password } = body
+  if (!email || !password) {
+    throw createError({ statusCode: 400, statusMessage: '資料不足' })
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } })
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: '帳號不存在' })
+  }
+
+  const valid = await bcrypt.compare(password, user.password)
+  if (!valid) {
+    throw createError({ statusCode: 401, statusMessage: '密碼錯誤' })
+  }
+
+  const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET as string)
+  setCookie(event, 'token', token, { httpOnly: true, path: '/' })
+  return { id: user.id, email: user.email }
+})

--- a/app/server/api/logout.post.ts
+++ b/app/server/api/logout.post.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(async (event) => {
+  setCookie(event, 'token', '', { httpOnly: true, path: '/', maxAge: 0 })
+  return { message: '已登出' }
+})

--- a/app/server/api/register.post.ts
+++ b/app/server/api/register.post.ts
@@ -1,0 +1,29 @@
+import { prisma } from '#utils/prisma'
+import { H3Error, createError } from 'h3'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+import Stripe from 'stripe'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { email, password } = body
+  if (!email || !password) {
+    throw createError({ statusCode: 400, statusMessage: '資料不足' })
+  }
+
+  const exists = await prisma.user.findUnique({ where: { email } })
+  if (exists) {
+    throw createError({ statusCode: 409, statusMessage: '帳號已存在' })
+  }
+
+  const hashed = await bcrypt.hash(password, 10)
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, { apiVersion: '2023-08-16' })
+  const customer = await stripe.customers.create({ email })
+  const user = await prisma.user.create({
+    data: { email, password: hashed, stripeCustomerId: customer.id }
+  })
+
+  const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET as string)
+  setCookie(event, 'token', token, { httpOnly: true, path: '/' })
+  return { id: user.id, email: user.email }
+})

--- a/app/server/api/subscription/cancel.post.ts
+++ b/app/server/api/subscription/cancel.post.ts
@@ -1,0 +1,23 @@
+import { prisma } from '#utils/prisma'
+import { verifyToken } from '#utils/auth'
+import { createError } from 'h3'
+import Stripe from 'stripe'
+
+export default defineEventHandler(async (event) => {
+  const userId = verifyToken(event)
+  if (!userId) {
+    setResponseStatus(event, 401)
+    return {}
+  }
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user || !user.subscriptionId) {
+    throw createError({ statusCode: 404, statusMessage: '無訂閱紀錄' })
+  }
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, { apiVersion: '2023-08-16' })
+  await stripe.subscriptions.del(user.subscriptionId)
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { subscriptionId: null, subscriptionStatus: 'canceled' }
+  })
+  return { status: 'canceled' }
+})

--- a/app/server/api/subscription/index.get.ts
+++ b/app/server/api/subscription/index.get.ts
@@ -1,0 +1,19 @@
+import { prisma } from '#utils/prisma'
+import { verifyToken } from '#utils/auth'
+import Stripe from 'stripe'
+
+export default defineEventHandler(async (event) => {
+  const userId = verifyToken(event)
+  if (!userId) {
+    setResponseStatus(event, 401)
+    return {}
+  }
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user || !user.subscriptionId) {
+    return { status: user?.subscriptionStatus || null }
+  }
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, { apiVersion: '2023-08-16' })
+  const subscription = await stripe.subscriptions.retrieve(user.subscriptionId)
+  await prisma.user.update({ where: { id: user.id }, data: { subscriptionStatus: subscription.status } })
+  return { status: subscription.status }
+})

--- a/app/server/api/user.get.ts
+++ b/app/server/api/user.get.ts
@@ -1,0 +1,20 @@
+import { prisma } from '#utils/prisma'
+import { verifyToken } from '#utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const userId = verifyToken(event)
+  if (!userId) {
+    setResponseStatus(event, 401)
+    return { }
+  }
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user) {
+    setResponseStatus(event, 404)
+    return {}
+  }
+  return {
+    id: user.id,
+    email: user.email,
+    subscriptionStatus: user.subscriptionStatus
+  }
+})

--- a/app/server/utils/auth.ts
+++ b/app/server/utils/auth.ts
@@ -1,0 +1,13 @@
+import jwt from 'jsonwebtoken'
+import { H3Event } from 'h3'
+
+export function verifyToken(event: H3Event): number | null {
+  const token = getCookie(event, 'token')
+  if (!token) return null
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as { id: number }
+    return decoded.id
+  } catch {
+    return null
+  }
+}

--- a/app/server/utils/prisma.ts
+++ b/app/server/utils/prisma.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client'
+
+export const prisma = new PrismaClient()


### PR DESCRIPTION
## Summary
- 新增 `bcryptjs`、`jsonwebtoken`、`stripe` 相依套件
- 更新 `.env.example` 範例加入 `STRIPE_SECRET_KEY` 與 `JWT_SECRET`
- 擴充 Prisma schema，加入 `User` 模型
- 新增註冊、登入、登出與訂閱查詢及取消的 API
- 加入 `auth` 中介軟體與 Prisma、JWT 輔助程式
- 新增 `login`、`register`、`dashboard` 頁面
- 首頁提供登入、註冊與 Dashboard 連結
- `README` 說明新增的環境變數與 Dashboard 功能

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_68735e7ad898832992ff0e0b165205ae