### PR TITLE
Add typed SubscriptionRes interface

### DIFF
--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -12,8 +12,11 @@
 <script setup lang="ts">
 definePageMeta({ middleware: 'auth' })
 
-const { data, pending, refresh } = await useFetch('/api/subscription')
-const status = computed(() => data.value?.status)
+interface SubscriptionRes { status: string | null }
+
+const { data, pending, refresh } =
+  await useFetch<SubscriptionRes>('/api/subscription')
+const status = computed(() => data.value?.status ?? null)
 
 const cancel = async () => {
   await $fetch('/api/subscription/cancel', { method: 'POST' })


### PR DESCRIPTION
## Summary
- define `SubscriptionRes` interface in dashboard page
- use typed `useFetch` for subscription API

## Testing
- `npm run build` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c37cb68c8329bae5f031fe3fba1d