### PR TITLE
Update auth middleware to send cookie header

### DIFF
--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -1,5 +1,7 @@
 export default defineNuxtRouteMiddleware(async () => {
-  const { data } = await useFetch('/api/user')
+  const { data } = await useFetch('/api/user', {
+    headers: useRequestHeaders(['cookie'])
+  })
   if (!data.value || !(data.value as any).id) {
     return navigateTo('/login')
   }


### PR DESCRIPTION
## Summary
- include cookie header when fetching user in auth middleware

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873c3834afc83299a3c1388094e44c0