### PR TITLE
Add subscription plan checkout

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -95,7 +95,7 @@
           <p class="mb-4">含兩片 NFC 板及設定</p>
           <button
             class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            @click="goCheckout"
+            @click="goCheckout('one-time')"
           >
             立即購買
           </button>
@@ -106,7 +106,7 @@
           <p class="mb-4">每月收費，隨時取消</p>
           <button
             class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-            @click="goCheckout"
+            @click="goCheckout('subscription')"
           >
             立即訂閱
           </button>
@@ -171,13 +171,13 @@ interface CheckoutSessionRes {
   url: string
 }
 
-const goCheckout = async () => {
+const goCheckout = async (plan?: string) => {
   if (loading.value) return
   loading.value = true
   try {
     const { url } = await $fetch<CheckoutSessionRes>(
       '/api/create-checkout-session',
-      { method: 'POST' }
+      { method: 'POST', body: { plan } }
     )
     window.location.href = url
   } finally {

--- a/app/server/api/create-checkout-session.post.ts
+++ b/app/server/api/create-checkout-session.post.ts
@@ -1,26 +1,70 @@
 import Stripe from 'stripe'
+import { prisma } from '#utils/prisma'
+import { verifyToken } from '#utils/auth'
 
 export default defineEventHandler(async (event) => {
+  const userId = verifyToken(event)
+  if (!userId) {
+    setResponseStatus(event, 401)
+    return {}
+  }
+
+  const body = await readBody(event)
+  const plan = body?.plan as string | undefined
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user) {
+    setResponseStatus(event, 404)
+    return {}
+  }
+
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
     apiVersion: '2023-08-16'
   })
 
-  const session = await stripe.checkout.sessions.create({
-    mode: 'payment',
-    payment_method_types: ['card'],
-    line_items: [
-      {
-        price_data: {
-          currency: 'myr',
-          product_data: { name: 'NFC 評論板組' },
-          unit_amount: 19900
-        },
-        quantity: 1
-      }
-    ],
-    success_url: `${getRequestURL(event).origin}/dashboard`,
-    cancel_url: `${getRequestURL(event).origin}/`
-  })
+  let session: Stripe.Checkout.Session
+  if (plan === 'subscription') {
+    session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'myr',
+            product_data: { name: 'NFC 評論板組 月租' },
+            unit_amount: 1990,
+            recurring: { interval: 'month' }
+          },
+          quantity: 1
+        }
+      ],
+      customer: user.stripeCustomerId || undefined,
+      success_url: `${getRequestURL(event).origin}/dashboard`,
+      cancel_url: `${getRequestURL(event).origin}/`
+    })
+    if (session.subscription) {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { subscriptionId: session.subscription as string }
+      })
+    }
+  } else {
+    session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'myr',
+            product_data: { name: 'NFC 評論板組' },
+            unit_amount: 19900
+          },
+          quantity: 1
+        }
+      ],
+      success_url: `${getRequestURL(event).origin}/dashboard`,
+      cancel_url: `${getRequestURL(event).origin}/`
+    })
+  }
 
   return { url: session.url }
 })


### PR DESCRIPTION
## Summary
- pass plan type to checkout from pricing buttons
- support `subscription` or `one-time` mode when creating Stripe Checkout sessions
- store `subscriptionId` for subscription purchases

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6873c9d006d08329af45a9572c374f44