### PR TITLE
Implement user verification in checkout API

### DIFF
--- a/app/server/api/create-checkout-session.post.ts
+++ b/app/server/api/create-checkout-session.post.ts
@@ -1,6 +1,18 @@
 import Stripe from 'stripe'
+import { prisma } from '#utils/prisma'
+import { verifyToken } from '#utils/auth'
+import { createError } from 'h3'
 
 export default defineEventHandler(async (event) => {
+  const userId = verifyToken(event)
+  if (!userId) {
+    setResponseStatus(event, 401)
+    return {}
+  }
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: '帳號不存在' })
+  }
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
     apiVersion: '2023-08-16'
   })


### PR DESCRIPTION
## Summary
- 於 `create-checkout-session` API 新增 token 驗證
- 查詢使用者資料並在缺失時回傳對應錯誤

## Testing
- `npm test` *(無測試腳本，指令失敗)*

------
https://chatgpt.com/codex/tasks/task_e_6873c9d12898832983e5bd4ead116be2