### PR TITLE
Implement Stripe webhook handler

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,6 +59,7 @@ Prisma schema 位於 `app/prisma/schema.prisma`，`server/routes/` 目前為空�
    ```env
    DATABASE_URL=mongodb://localhost:27017/nfc
    STRIPE_SECRET_KEY=your_stripe_secret
+   STRIPE_WEBHOOK_SECRET=your_webhook_secret
    JWT_SECRET=your_jwt_secret
    GA_ID=G-XXXX
    ```
@@ -106,6 +107,7 @@ Prisma schema 位於 `app/prisma/schema.prisma`，`server/routes/` 目前為空�
 3. 在頁面上留下好評或透過 Stripe 完成付款流程。
 4. 後台可查看累積的好評與交易紀錄。
 5. 會員登入後可於 Dashboard 檢視訂閱狀態並隨時取消。
+6. 在 Stripe 後台設定 Webhook 指向 `/api/stripe-webhook`，並於 `.env` 填入 `STRIPE_WEBHOOK_SECRET`。
 
 ## Landing Page 特色
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL="mongodb://localhost:27017/nfc"
 STRIPE_SECRET_KEY="sk_test_your_key"
+STRIPE_WEBHOOK_SECRET="whsec_your_secret"
 JWT_SECRET="your_jwt_secret"
 GA_ID="G-XXXX"

--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -8,5 +8,8 @@ export default defineNuxtConfig({
   },
   alias: {
     '#utils': resolve(__dirname, 'server/utils')
+  },
+  runtimeConfig: {
+    stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET
   }
 })

--- a/app/server/api/stripe-webhook.post.ts
+++ b/app/server/api/stripe-webhook.post.ts
@@ -1,0 +1,54 @@
+import Stripe from 'stripe'
+import { prisma } from '#utils/prisma'
+
+export const config = {
+  bodyParser: false
+}
+
+export default defineEventHandler(async (event) => {
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+    apiVersion: '2023-08-16'
+  })
+  const rawBody = await readRawBody(event)
+  const signature = getHeader(event, 'stripe-signature') || ''
+  const { stripeWebhookSecret } = useRuntimeConfig()
+  let stripeEvent: Stripe.Event
+  try {
+    stripeEvent = stripe.webhooks.constructEvent(
+      rawBody!.toString(),
+      signature,
+      stripeWebhookSecret as string
+    )
+  } catch {
+    setResponseStatus(event, 400)
+    return { error: 'Invalid signature' }
+  }
+
+  if (
+    stripeEvent.type === 'checkout.session.completed' ||
+    stripeEvent.type === 'invoice.paid'
+  ) {
+    let customerId: string | null = null
+    let subscriptionId: string | null = null
+    if (stripeEvent.type === 'checkout.session.completed') {
+      const session = stripeEvent.data.object as Stripe.Checkout.Session
+      customerId = session.customer as string
+      subscriptionId = session.subscription as string | null
+    } else {
+      const invoice = stripeEvent.data.object as Stripe.Invoice
+      customerId = invoice.customer as string
+      subscriptionId =
+        typeof invoice.subscription === 'string'
+          ? invoice.subscription
+          : invoice.subscription?.id || null
+    }
+    if (customerId && subscriptionId) {
+      await prisma.user.updateMany({
+        where: { stripeCustomerId: customerId },
+        data: { subscriptionId, subscriptionStatus: 'active' }
+      })
+    }
+  }
+
+  return { received: true }
+})


### PR DESCRIPTION
## Summary
- add webhook endpoint `/api/stripe-webhook` to validate events
- update subscription fields on checkout or invoice events
- expose `stripeWebhookSecret` via `runtimeConfig`
- document webhook setup and env var

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c9d20cec8329ba5cdb98de0bfed1