### PR TITLE
調整 Cookie 安全性設定

### DIFF
--- a/app/server/api/login.post.ts
+++ b/app/server/api/login.post.ts
@@ -21,6 +21,11 @@ export default defineEventHandler(async (event) => {
   }
 
   const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET as string)
-  setCookie(event, 'token', token, { httpOnly: true, path: '/' })
+  setCookie(event, 'token', token, {
+    httpOnly: true,
+    path: '/',
+    secure: true,
+    sameSite: 'lax'
+  })
   return { id: user.id, email: user.email }
 })

--- a/app/server/api/logout.post.ts
+++ b/app/server/api/logout.post.ts
@@ -1,4 +1,10 @@
 export default defineEventHandler(async (event) => {
-  setCookie(event, 'token', '', { httpOnly: true, path: '/', maxAge: 0 })
+  setCookie(event, 'token', '', {
+    httpOnly: true,
+    path: '/',
+    maxAge: 0,
+    secure: true,
+    sameSite: 'lax'
+  })
   return { message: '已登出' }
 })

--- a/app/server/api/register.post.ts
+++ b/app/server/api/register.post.ts
@@ -24,6 +24,11 @@ export default defineEventHandler(async (event) => {
   })
 
   const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET as string)
-  setCookie(event, 'token', token, { httpOnly: true, path: '/' })
+  setCookie(event, 'token', token, {
+    httpOnly: true,
+    path: '/',
+    secure: true,
+    sameSite: 'lax'
+  })
   return { id: user.id, email: user.email }
 })


### PR DESCRIPTION
## Summary
- 為登入與註冊 API 新增 `secure` 與 `sameSite` 屬性
- 登出時以相同設定清除 Cookie

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873c9d366b883299ce3c6e6a102ff8e