### PR TITLE
Expose GA_ID via runtime config

### DIFF
--- a/app/nuxt.config.ts
+++ b/app/nuxt.config.ts
@@ -8,5 +8,10 @@ export default defineNuxtConfig({
   },
   alias: {
     '#utils': resolve(__dirname, 'server/utils')
+  },
+  runtimeConfig: {
+    public: {
+      GA_ID: process.env.GA_ID
+    }
   }
 })

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -143,6 +143,7 @@
 </template>
 
 <script setup lang="ts">
+const config = useRuntimeConfig()
 useHead({
   title: 'NFC 評論系統 - 一觸獲五星好評',
   meta: [
@@ -153,13 +154,13 @@ useHead({
     }
   ],
   script: [
-    { src: 'https://www.googletagmanager.com/gtag/js?id=G-XXXX', async: true },
+    { src: `https://www.googletagmanager.com/gtag/js?id=${config.public.GA_ID}`, async: true },
     {
       innerHTML: `
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'G-XXXX');
+        gtag('config', '${config.public.GA_ID}');
       `,
       type: 'text/javascript'
     }


### PR DESCRIPTION
## Summary
- expose `GA_ID` from `.env` via `runtimeConfig`
- use runtime config on landing page

## Testing
- `grep -n GA_ID -R app | head`

------
https://chatgpt.com/codex/tasks/task_e_6873c9d3dd448329af2d94a4cf6098a3