### PR TITLE
新增預設版型與導覽列

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,3 +1,5 @@
 <template>
-  <NuxtPage />
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
 </template>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <header class="p-4 bg-gray-100 flex gap-4">
+      <NuxtLink to="/" class="hover:underline">Home</NuxtLink>
+      <NuxtLink to="/login" class="hover:underline">Login</NuxtLink>
+      <NuxtLink to="/register" class="hover:underline">Register</NuxtLink>
+      <NuxtLink to="/dashboard" class="hover:underline">Dashboard</NuxtLink>
+    </header>
+    <main>
+      <slot />
+    </main>
+  </div>
+</template>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup lang="ts">
-definePageMeta({ middleware: 'auth' })
+definePageMeta({ middleware: "auth", layout: "default" })
 
 interface SubscriptionRes { status: string | null }
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -143,6 +143,7 @@
 </template>
 
 <script setup lang="ts">
+definePageMeta({ layout: "default" })
 const config = useRuntimeConfig()
 useHead({
   title: 'NFC 評論系統 - 一觸獲五星好評',

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script setup lang="ts">
+definePageMeta({ layout: "default" })
 const email = ref('')
 const password = ref('')
 

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script setup lang="ts">
+definePageMeta({ layout: "default" })
 const email = ref('')
 const password = ref('')
 


### PR DESCRIPTION
## Summary
- 建立 `default` 佈局並加入簡易 Header
- 調整 `app.vue` 以載入版型
- 各頁面套用 `default` 佈局

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873e87530cc8329baa7d89aaa21593d