### PR TITLE
改善登入與註冊表單

### DIFF
--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,10 +1,19 @@
 <template>
   <div class="max-w-md mx-auto p-4">
     <h1 class="text-xl font-bold mb-4">會員登入</h1>
-    <form @submit.prevent="onSubmit" class="space-y-4">
-      <input v-model="email" type="email" placeholder="Email" class="w-full border p-2" />
-      <input v-model="password" type="password" placeholder="Password" class="w-full border p-2" />
+  <form @submit.prevent="onSubmit" class="space-y-4">
+      <div>
+        <label for="login-email" class="block mb-1">Email</label>
+        <input id="login-email" v-model="email" type="email" required placeholder="Email" class="w-full border p-2" />
+      </div>
+      <div>
+        <label for="login-password" class="block mb-1">Password</label>
+        <input id="login-password" v-model="password" type="password" required placeholder="Password" class="w-full border p-2" />
+      </div>
       <button type="submit" class="px-4 py-2 bg-blue-500 text-white">登入</button>
+      <p v-if="errorMsg" class="text-red-700 bg-red-100 border border-red-500 rounded p-2">
+        {{ errorMsg }}
+      </p>
     </form>
   </div>
 </template>
@@ -12,9 +21,18 @@
 <script setup lang="ts">
 const email = ref('')
 const password = ref('')
+const errorMsg = ref('')
 
 const onSubmit = async () => {
-  await $fetch('/api/login', { method: 'POST', body: { email: email.value, password: password.value } })
-  await navigateTo('/dashboard')
+  errorMsg.value = ''
+  try {
+    await $fetch('/api/login', {
+      method: 'POST',
+      body: { email: email.value, password: password.value }
+    })
+    await navigateTo('/dashboard')
+  } catch (err: any) {
+    errorMsg.value = err?.data?.statusMessage || '登入失敗，請稍後再試'
+  }
 }
 </script>

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -2,9 +2,18 @@
   <div class="max-w-md mx-auto p-4">
     <h1 class="text-xl font-bold mb-4">會員註冊</h1>
     <form @submit.prevent="onSubmit" class="space-y-4">
-      <input v-model="email" type="email" placeholder="Email" class="w-full border p-2" />
-      <input v-model="password" type="password" placeholder="Password" class="w-full border p-2" />
+      <div>
+        <label for="reg-email" class="block mb-1">Email</label>
+        <input id="reg-email" v-model="email" type="email" required placeholder="Email" class="w-full border p-2" />
+      </div>
+      <div>
+        <label for="reg-password" class="block mb-1">Password</label>
+        <input id="reg-password" v-model="password" type="password" required placeholder="Password" class="w-full border p-2" />
+      </div>
       <button type="submit" class="px-4 py-2 bg-blue-500 text-white">註冊</button>
+      <p v-if="errorMsg" class="text-red-700 bg-red-100 border border-red-500 rounded p-2">
+        {{ errorMsg }}
+      </p>
     </form>
   </div>
 </template>
@@ -12,9 +21,18 @@
 <script setup lang="ts">
 const email = ref('')
 const password = ref('')
+const errorMsg = ref('')
 
 const onSubmit = async () => {
-  await $fetch('/api/register', { method: 'POST', body: { email: email.value, password: password.value } })
-  await navigateTo('/dashboard')
+  errorMsg.value = ''
+  try {
+    await $fetch('/api/register', {
+      method: 'POST',
+      body: { email: email.value, password: password.value }
+    })
+    await navigateTo('/dashboard')
+  } catch (err: any) {
+    errorMsg.value = err?.data?.statusMessage || '註冊失敗，請稍後再試'
+  }
 }
 </script>


### PR DESCRIPTION
## 變更內容
- 加入 `try...catch` 於登入與註冊的 `onSubmit`，失敗時顯示錯誤訊息
- 為 `email`、`password` 欄位補上 `label` 與 `required` 屬性
- 新增錯誤訊息樣式，採用 Tailwind

## 測試結果
- `npm test`（無測試腳本）【b122cb†L1-L11】


------
https://chatgpt.com/codex/tasks/task_e_6873e992d87c8329ab6c13a41b462fd8