### PR TITLE
改善註冊及登入表單錯誤處理

### DIFF
--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -6,15 +6,17 @@
         v-model="email"
         type="email"
         placeholder="Email"
-        class="w-full border border-gray-300 rounded p-2"
+        autocomplete="email"
+        class="w-full border border-gray-300 rounded px-4 py-2"
       />
       <input
         v-model="password"
         type="password"
         placeholder="Password"
-        class="w-full border border-gray-300 rounded p-2"
+        autocomplete="current-password"
+        class="w-full border border-gray-300 rounded px-4 py-2"
       />
-      <p v-if="errorMsg" class="text-red-500">{{ errorMsg }}</p>
+      <p v-if="errorMsg" class="text-red-500 text-sm">{{ errorMsg }}</p>
       <button
         type="submit"
         class="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
@@ -26,9 +28,9 @@
 </template>
 
 <script setup lang="ts">
-const email = ref('')
-const password = ref('')
-const errorMsg = ref('')
+const email = ref<string>('')
+const password = ref<string>('')
+const errorMsg = ref<string>('')
 
 const onSubmit = async () => {
   errorMsg.value = ''

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -2,9 +2,25 @@
   <div class="max-w-md mx-auto p-4">
     <h1 class="text-xl font-bold mb-4">會員登入</h1>
     <form @submit.prevent="onSubmit" class="space-y-4">
-      <input v-model="email" type="email" placeholder="Email" class="w-full border p-2" />
-      <input v-model="password" type="password" placeholder="Password" class="w-full border p-2" />
-      <button type="submit" class="px-4 py-2 bg-blue-500 text-white">登入</button>
+      <input
+        v-model="email"
+        type="email"
+        placeholder="Email"
+        class="w-full border border-gray-300 rounded p-2"
+      />
+      <input
+        v-model="password"
+        type="password"
+        placeholder="Password"
+        class="w-full border border-gray-300 rounded p-2"
+      />
+      <p v-if="errorMsg" class="text-red-500">{{ errorMsg }}</p>
+      <button
+        type="submit"
+        class="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        登入
+      </button>
     </form>
   </div>
 </template>
@@ -12,9 +28,18 @@
 <script setup lang="ts">
 const email = ref('')
 const password = ref('')
+const errorMsg = ref('')
 
 const onSubmit = async () => {
-  await $fetch('/api/login', { method: 'POST', body: { email: email.value, password: password.value } })
-  await navigateTo('/dashboard')
+  errorMsg.value = ''
+  try {
+    await $fetch('/api/login', {
+      method: 'POST',
+      body: { email: email.value, password: password.value }
+    })
+    await navigateTo('/dashboard')
+  } catch (err: any) {
+    errorMsg.value = err?.data?.statusMessage || '登入失敗'
+  }
 }
 </script>

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -6,15 +6,17 @@
         v-model="email"
         type="email"
         placeholder="Email"
-        class="w-full border border-gray-300 rounded p-2"
+        autocomplete="email"
+        class="w-full border border-gray-300 rounded px-4 py-2"
       />
       <input
         v-model="password"
         type="password"
         placeholder="Password"
-        class="w-full border border-gray-300 rounded p-2"
+        autocomplete="new-password"
+        class="w-full border border-gray-300 rounded px-4 py-2"
       />
-      <p v-if="errorMsg" class="text-red-500">{{ errorMsg }}</p>
+      <p v-if="errorMsg" class="text-red-500 text-sm">{{ errorMsg }}</p>
       <button
         type="submit"
         class="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
@@ -26,9 +28,9 @@
 </template>
 
 <script setup lang="ts">
-const email = ref('')
-const password = ref('')
-const errorMsg = ref('')
+const email = ref<string>('')
+const password = ref<string>('')
+const errorMsg = ref<string>('')
 
 const onSubmit = async () => {
   errorMsg.value = ''

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -2,9 +2,25 @@
   <div class="max-w-md mx-auto p-4">
     <h1 class="text-xl font-bold mb-4">會員註冊</h1>
     <form @submit.prevent="onSubmit" class="space-y-4">
-      <input v-model="email" type="email" placeholder="Email" class="w-full border p-2" />
-      <input v-model="password" type="password" placeholder="Password" class="w-full border p-2" />
-      <button type="submit" class="px-4 py-2 bg-blue-500 text-white">註冊</button>
+      <input
+        v-model="email"
+        type="email"
+        placeholder="Email"
+        class="w-full border border-gray-300 rounded p-2"
+      />
+      <input
+        v-model="password"
+        type="password"
+        placeholder="Password"
+        class="w-full border border-gray-300 rounded p-2"
+      />
+      <p v-if="errorMsg" class="text-red-500">{{ errorMsg }}</p>
+      <button
+        type="submit"
+        class="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        註冊
+      </button>
     </form>
   </div>
 </template>
@@ -12,9 +28,18 @@
 <script setup lang="ts">
 const email = ref('')
 const password = ref('')
+const errorMsg = ref('')
 
 const onSubmit = async () => {
-  await $fetch('/api/register', { method: 'POST', body: { email: email.value, password: password.value } })
-  await navigateTo('/dashboard')
+  errorMsg.value = ''
+  try {
+    await $fetch('/api/register', {
+      method: 'POST',
+      body: { email: email.value, password: password.value }
+    })
+    await navigateTo('/dashboard')
+  } catch (err: any) {
+    errorMsg.value = err?.data?.statusMessage || '註冊失敗'
+  }
 }
 </script>


### PR DESCRIPTION
## 變更內容
- 登入與註冊頁加入 `try...catch` 與 `errorMsg`
- 統一輸入框及按鈕樣式，提高可讀性
- 註冊與登入失敗時顯示錯誤訊息，成功則導向 `/dashboard`

## 測試
- `npm test` *(無此指令)*
- `npm run lint` *(無此指令)*
- `npm run build` 失敗：`nuxt: not found`

------
https://chatgpt.com/codex/tasks/task_e_6873e999fb348329bdfff3b720cb9b66