### PR TITLE
Add billing portal session API

### DIFF
--- a/app/server/api/billing/portal-session.post.ts
+++ b/app/server/api/billing/portal-session.post.ts
@@ -1,0 +1,31 @@
+import Stripe from 'stripe'
+import { prisma } from '#utils/prisma'
+import { verifyToken } from '#utils/auth'
+import { createError } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const userId = verifyToken(event)
+  if (!userId) {
+    setResponseStatus(event, 401)
+    return {}
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user) {
+    throw createError({ statusCode: 404, statusMessage: '帳號不存在' })
+  }
+  if (!user.stripeCustomerId) {
+    throw createError({ statusCode: 400, statusMessage: '找不到 Stripe 客戶' })
+  }
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+    apiVersion: '2023-08-16'
+  })
+
+  const session = await stripe.billingPortal.sessions.create({
+    customer: user.stripeCustomerId,
+    return_url: `${getRequestURL(event).origin}/dashboard`
+  })
+
+  return { url: session.url }
+})


### PR DESCRIPTION
## Summary
- add `portal-session.post.ts` to create Stripe billing portal sessions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873fae6f0548329a6b3dca76f5c5de8