### PR TITLE
新增帳單管理功能

### DIFF
--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -1,0 +1,20 @@
+import axios from 'axios'
+import { useAuthStore } from '../stores/auth'
+
+export function useApi() {
+  const config = useRuntimeConfig()
+  const instance = axios.create({
+    baseURL: config.public?.API_BASE_URL || ''
+  })
+
+  instance.interceptors.request.use((request) => {
+    const store = useAuthStore()
+    if (store.accessToken) {
+      request.headers = request.headers || {}
+      ;(request.headers as any).Authorization = `Bearer ${store.accessToken}`
+    }
+    return request
+  })
+
+  return instance
+}

--- a/app/composables/useBilling.ts
+++ b/app/composables/useBilling.ts
@@ -1,0 +1,18 @@
+import { useApi } from './useApi'
+
+interface PortalSessionRes {
+  url: string
+}
+
+export function useBilling() {
+  const api = useApi()
+
+  const openPortal = async () => {
+    const { data } = await api.post<PortalSessionRes>('/billing/portal-session')
+    if (process.client && data.url) {
+      window.location.href = data.url
+    }
+  }
+
+  return { openPortal }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,8 @@
     "stripe": "^12.17.0",
     "tailwindcss": "^3.3.5",
     "pinia": "^2.1.7",
-    "@auth/core": "^0.12.0"
+    "@auth/core": "^0.12.0",
+    "axios": "^1.6.7"
   },
   "devDependencies": {
     "@types/node": "^20.5.9",

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -18,6 +18,13 @@
         >
           取消訂閱
         </button>
+        <button
+          v-if="status"
+          @click="onPortal"
+          class="mt-4 ml-2 px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          管理訂閱
+        </button>
       </div>
       <button
         class="px-4 py-2 bg-gray-600 text-white rounded"
@@ -61,6 +68,11 @@ const onCancel = async () => {
   if (confirm('確定要取消訂閱嗎？')) {
     await cancel()
   }
+}
+
+const { openPortal } = useBilling()
+const onPortal = async () => {
+  await openPortal()
 }
 
 const { logout } = useAuth()


### PR DESCRIPTION
## Summary
- 建立 `useApi` composable 並在攔截器加入 `Authorization`
- 新增 `useBilling`，透過 API 取得 Portal 連結後導向
- Dashboard 新增「管理訂閱」按鈕並呼叫 `openPortal`
- 將 `axios` 列入依賴

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873fce0af18832998bb2462bb194ebf