### PR TITLE
Add user usage API and update dashboard

### DIFF
--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1,17 +1,18 @@
 <template>
   <div class="p-4 space-y-4">
     <h1 class="text-xl font-bold mb-4">會員儀表板</h1>
-    <div v-if="pendingUser || pendingSub">載入中...</div>
+    <div v-if="pendingUser || pendingSub || pendingUsage">載入中...</div>
     <div v-else class="space-y-4">
       <div class="bg-gray-50 p-4 rounded shadow">
         <h2 class="font-semibold mb-2">會員資料</h2>
         <p>Email：{{ user?.email }}</p>
       </div>
       <div class="bg-gray-50 p-4 rounded shadow">
-        <h2 class="font-semibold mb-2">訂閱狀態</h2>
-        <p>狀態：{{ status || '無' }}</p>
-        <p v-if="expiration">到期日：{{ expiration }}</p>
-        <button
+        <h2 class="font-semibold mb-2">方案資訊</h2>
+        <p>方案：{{ usage?.plan }}</p>
+        <p>額度：{{ usage?.quota }}</p>
+        <p v-if="exp">到期日：{{ exp }}</p>
+      <button
           v-if="status && status !== 'canceled'"
           @click="onCancel"
           class="mt-4 px-4 py-2 bg-red-500 text-white rounded"
@@ -48,14 +49,31 @@ interface UserRes {
   email: string
 }
 
+interface UsageRes {
+  plan: string
+  quota: number
+  expiration: number | null
+}
+
 const { data: subData, pending: pendingSub, refresh } =
   await useFetch<SubscriptionRes>('/api/subscription')
 const { data: userData, pending: pendingUser } = await useFetch<UserRes>('/api/user')
 
+const api = useApi()
+const { data: usageData, pending: pendingUsage } = await useAsyncData(
+  'usage',
+  async () => {
+    const res = await api.get<UsageRes>('/api/user/usage')
+    return res.data
+  }
+)
+
 const user = computed(() => userData.value)
 const status = computed(() => subData.value?.status ?? null)
-const expiration = computed(() => {
-  const ts = subData.value?.currentPeriodEnd
+
+const usage = computed(() => usageData.value)
+const exp = computed(() => {
+  const ts = usageData.value?.expiration
   return ts ? new Date(ts * 1000).toLocaleDateString('zh-TW') : null
 })
 

--- a/app/server/api/user/usage.get.ts
+++ b/app/server/api/user/usage.get.ts
@@ -1,0 +1,38 @@
+import { prisma } from '#utils/prisma'
+import { verifyToken } from '#utils/auth'
+import Stripe from 'stripe'
+
+export default defineEventHandler(async (event) => {
+  const userId = verifyToken(event)
+  if (!userId) {
+    setResponseStatus(event, 401)
+    return {}
+  }
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user) {
+    setResponseStatus(event, 404)
+    return {}
+  }
+
+  const plan = user.subscriptionStatus === 'active' ? 'pro' : 'basic'
+  const quota = plan === 'pro' ? 1000 : 100
+  let expiration: number | null = null
+
+  if (user.subscriptionId && plan === 'pro') {
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+      apiVersion: '2023-08-16'
+    })
+    try {
+      const sub = await stripe.subscriptions.retrieve(user.subscriptionId)
+      expiration = sub.current_period_end
+    } catch {
+      expiration = null
+    }
+  }
+
+  return {
+    plan,
+    quota,
+    expiration
+  }
+})


### PR DESCRIPTION
## Summary
- add usage API endpoint
- load and display plan info on dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873fe5f91e08329a8f8ff87c683da1b