### PR TITLE
Add global CORS middleware

### DIFF
--- a/app/server/middleware/cors.ts
+++ b/app/server/middleware/cors.ts
@@ -1,0 +1,11 @@
+export default defineEventHandler((event) => {
+  setHeader(event, 'Access-Control-Allow-Origin', 'https://billing.example.com')
+  setHeader(event, 'Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS')
+  setHeader(event, 'Access-Control-Allow-Headers', 'Authorization,Content-Type')
+  setHeader(event, 'Access-Control-Allow-Credentials', 'true')
+
+  if (event.node.req.method === 'OPTIONS') {
+    setResponseStatus(event, 200)
+    return ''
+  }
+})


### PR DESCRIPTION
## Summary
- add server middleware to apply CORS headers on every response

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: nuxt: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687401b4de888329b25f9c435d60d119