### PR TITLE
新增 Stripe Billing Portal 入口 API

### DIFF
--- a/app/composables/useBilling.ts
+++ b/app/composables/useBilling.ts
@@ -8,7 +8,7 @@ export function useBilling() {
   const api = useApi()
 
   const openPortal = async () => {
-    const { data } = await api.post<PortalSessionRes>('/billing/portal-session')
+    const { data } = await api.post<PortalSessionRes>('/api/billing/portal-session')
     if (process.client && data.url) {
       window.location.href = data.url
     }

--- a/app/server/api/billing/portal-session.post.ts
+++ b/app/server/api/billing/portal-session.post.ts
@@ -1,0 +1,28 @@
+import Stripe from 'stripe'
+import { prisma } from '#utils/prisma'
+import { verifyToken } from '#utils/auth'
+import { createError } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const userId = verifyToken(event)
+  if (!userId) {
+    setResponseStatus(event, 401)
+    return {}
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user || !user.stripeCustomerId) {
+    throw createError({ statusCode: 404, statusMessage: '無客戶資料' })
+  }
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+    apiVersion: '2023-08-16'
+  })
+
+  const session = await stripe.billingPortal.sessions.create({
+    customer: user.stripeCustomerId,
+    return_url: `${getRequestURL(event).origin}/dashboard`
+  })
+
+  return { url: session.url }
+})


### PR DESCRIPTION
## Summary
- 新增 `billing/portal-session.post.ts` 透過 Stripe 建立 Billing Portal session
- 調整 `useBilling` 內 API 路徑為 `/api/billing/portal-session`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687422641a5c8329bedf6c04bdb2a165