### PR TITLE
fix duplicate user check

### DIFF
--- a/app/server/api/create-checkout-session.post.ts
+++ b/app/server/api/create-checkout-session.post.ts
@@ -18,10 +18,6 @@ export default defineEventHandler(async (event) => {
 
   const body = await readBody(event)
   const plan = body?.plan as string | undefined
-  if (!user) {
-    setResponseStatus(event, 404)
-    return {}
-  }
 
 
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {


### PR DESCRIPTION
## Summary
- remove redundant user check in `create-checkout-session` endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: nuxt not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68742670e4b083298a5cee78fe05dffd