### PR TITLE
Update Mongo script path

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -9,8 +9,10 @@
 cd app
 cp .env.example .env  # 建立環境設定檔
 npm install        # 如環境允許，安裝相依套件
-npm run dev        # 啟動開發伺服器
+npm run dev        # 啟動開發伺服器並自動啟動本地 MongoDB
 ```
+
+預設 `mongo` 指令會將資料儲存於 `./data/db` 目錄，如需其他路徑可自行調整 `app/package.json`。
 
 複製 `.env.example` 為 `.env` 後可調整資料庫連線字串，預設使用 MongoDB。
 

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "mongo": "mongod --dbpath C:\\\\data\\\\db --replSet rs0 --bind_ip 127.0.0.1",
+    "mongo": "mongod --dbpath ./data/db --replSet rs0 --bind_ip 127.0.0.1",
     "mongo:init": "mongosh --eval \"rs.initiate()\"",
     "dev": "concurrently \"npm run mongo\" \"nuxt dev\"",
     "build": "nuxt build",


### PR DESCRIPTION
## Summary
- use relative `./data/db` path for `mongod`
- clarify in README that MongoDB data defaults to that path

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68742bab2ebc8329825a819fdc8cf22c