### PR TITLE
加入 lint 與測試腳本

### DIFF
--- a/app/.eslintignore
+++ b/app/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+.nuxt
+.output

--- a/app/eslint.config.cjs
+++ b/app/eslint.config.cjs
@@ -1,0 +1,23 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:vue/vue3-recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    parser: '@typescript-eslint/parser',
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: [
+    'vue',
+    '@typescript-eslint',
+  ],
+  rules: {},
+};

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,9 @@
     "mongo:init": "mongosh --eval \"rs.initiate()\"",
     "dev": "concurrently \"npm run mongo\" \"nuxt dev\"",
     "build": "nuxt build",
-    "start": "nuxt start"
+    "start": "nuxt start",
+    "lint": "eslint . --ext .ts,.js,.vue",
+    "test": "vitest run"
   },
   "dependencies": {
     "@nuxtjs/tailwindcss": "^6.8.0",
@@ -26,6 +28,11 @@
     "autoprefixer": "^10.4.14",
     "prisma": "^5.22.0",
     "typescript": "^5.2.2",
-    "concurrently": "^8.2.2"
+    "concurrently": "^8.2.2",
+    "eslint": "^8.57.0",
+    "eslint-plugin-vue": "^9.25.0",
+    "@typescript-eslint/parser": "^7.8.0",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/app/test/add.test.ts
+++ b/app/test/add.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import { add } from '../utils/add'
+
+describe('add', () => {
+  it('should add two numbers', () => {
+    expect(add(1, 2)).toBe(3)
+  })
+})

--- a/app/tsconfig.vitest.json
+++ b/app/tsconfig.vitest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  }
+}

--- a/app/utils/add.ts
+++ b/app/utils/add.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}


### PR DESCRIPTION
## Summary
- 新增 `eslint`, `vitest` 等開發依賴
- 於 `app/package.json` 增加 `lint` 與 `test` 指令
- 提供簡易範例函式與測試
- 新增 ESLint 設定檔

## Testing
- `npm run lint` *(失敗：無法找到適當設定)*
- `npm run test` *(失敗：vitest 未安裝)*

------
https://chatgpt.com/codex/tasks/task_e_6874319afe908329978c03b546b0c528