### PR TITLE
更新：移除 axios 改用 Nuxt 內建 $fetch

### DIFF
--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -1,20 +1,19 @@
-import axios from 'axios'
 import { useAuthStore } from '../stores/auth'
 
-export function useApi() {
-  const config = useRuntimeConfig()
-  const instance = axios.create({
-    baseURL: config.public?.API_BASE_URL || ''
-  })
+export const useApi = () => {
+  const cfg = useRuntimeConfig()
 
-  instance.interceptors.request.use((request) => {
+  return async <T>(url: string, opts: FetchOptions = {}) => {
     const store = useAuthStore()
+    const headers = new Headers(opts.headers || {})
     if (store.accessToken) {
-      request.headers = request.headers || {}
-      ;(request.headers as any).Authorization = `Bearer ${store.accessToken}`
+      headers.set('Authorization', `Bearer ${store.accessToken}`)
     }
-    return request
-  })
 
-  return instance
+    return $fetch<T>(url, {
+      baseURL: cfg.public.apiBase ?? '/api',
+      ...opts,
+      headers
+    })
+  }
 }

--- a/app/composables/useBilling.ts
+++ b/app/composables/useBilling.ts
@@ -8,9 +8,12 @@ export function useBilling() {
   const api = useApi()
 
   const openPortal = async () => {
-    const { data } = await api.post<PortalSessionRes>('/api/billing/portal-session')
-    if (process.client && data.url) {
-      window.location.href = data.url
+    const { url } = await api<PortalSessionRes>('/billing/portal-session', {
+      method: 'POST'
+    })
+
+    if (process.client) {
+      window.location.href = url
     }
   }
 

--- a/app/package.json
+++ b/app/package.json
@@ -20,8 +20,7 @@
     "stripe": "^12.17.0",
     "tailwindcss": "^3.3.5",
     "pinia": "^2.1.7",
-    "@auth/core": "^0.12.0",
-    "axios": "^1.6.7"
+    "@auth/core": "^0.12.0"
   },
   "devDependencies": {
     "@types/node": "^20.5.9",

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -59,13 +59,8 @@ const { data: subData, pending: pendingSub, refresh } =
   await useFetch<SubscriptionRes>('/api/subscription')
 const { data: userData, pending: pendingUser } = await useFetch<UserRes>('/api/user')
 
-const api = useApi()
-const { data: usageData, pending: pendingUsage } = await useAsyncData(
-  'usage',
-  async () => {
-    const res = await api.get<UsageRes>('/api/user/usage')
-    return res.data
-  }
+const { data: usageData, pending: pendingUsage } = await useFetch<UsageRes>(
+  '/api/user/usage'
 )
 
 const user = computed(() => userData.value)


### PR DESCRIPTION
## Summary
- 移除 `axios` 依賴並改寫 `useApi`
- `useBilling` 及 `dashboard` 頁面全面改用 `$fetch`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_687491a994d08329ad75cc2f447d9d16