### PR TITLE
更新預設版面結構

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,11 +1,11 @@
 <template>
-  <div>
-    <header class="p-4 bg-gray-100 flex gap-4">
-      <NuxtLink to="/" class="hover:underline">Home</NuxtLink>
-      <NuxtLink to="/login" class="hover:underline">Login</NuxtLink>
-      <NuxtLink to="/register" class="hover:underline">Register</NuxtLink>
-      <NuxtLink to="/dashboard" class="hover:underline">Dashboard</NuxtLink>
-    </header>
+  <div class="flex">
+    <aside class="p-4 bg-gray-100 flex flex-col gap-4">
+      <NuxtLink to="/" class="hover:underline">首頁</NuxtLink>
+      <NuxtLink to="/login" class="hover:underline">登入</NuxtLink>
+      <NuxtLink to="/register" class="hover:underline">註冊</NuxtLink>
+      <NuxtLink to="/dashboard" class="hover:underline">儀表板</NuxtLink>
+    </aside>
     <main>
       <slot />
     </main>

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,7 @@
     "nuxt": "^3.10.3",
     "pinia": "^2.3.1",
     "stripe": "^12.17.0",
-    "tailwindcss": "^3.3.5",
+    "tailwindcss": "^3.3.5"
   },
   "devDependencies": {
     "@types/node": "^20.5.9",


### PR DESCRIPTION
## 摘要
- 將 `app/layouts/default.vue` 的版面調整為 `flex` 容器，並移除 `<header>`
- 在 `aside` 中加入垂直導覽列，連結文字改為中文
- 修正 `package.json` 中 `dependencies` 區塊的 JSON 格式

## 測試
- `npm install --prefix app` *(失敗：無法連線到 npm registry)*
- `npm test --prefix app` *(失敗：vitest 未安裝)*

------
https://chatgpt.com/codex/tasks/task_e_68749f61a01083298bea3ce503c31dfe