### PR TITLE
更新訂閱結帳流程

### DIFF
--- a/app/server/api/create-checkout-session.post.ts
+++ b/app/server/api/create-checkout-session.post.ts
@@ -16,56 +16,40 @@ export default defineEventHandler(async (event) => {
   }
 
 
-  const body = await readBody(event)
-  const plan = body?.plan as string | undefined
-
-
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
     apiVersion: '2023-08-16'
   })
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    payment_method_types: ['card'],
+    line_items: [
+      {
+        price_data: {
+          currency: 'myr',
+          product_data: { name: 'NFC 評論板組 月租' },
+          unit_amount: 1990,
+          recurring: { interval: 'month' }
+        },
+        quantity: 1
+      },
+      {
+        price_data: {
+          currency: 'myr',
+          product_data: { name: 'NFC 評論板組 建置費' },
+          unit_amount: 19900
+        },
+        quantity: 1
+      }
+    ],
+    customer: user.stripeCustomerId || undefined,
+    success_url: `${getRequestURL(event).origin}/dashboard`,
+    cancel_url: `${getRequestURL(event).origin}/`
+  })
 
-  let session: Stripe.Checkout.Session
-  if (plan === 'subscription') {
-    session = await stripe.checkout.sessions.create({
-      mode: 'subscription',
-      payment_method_types: ['card'],
-      line_items: [
-        {
-          price_data: {
-            currency: 'myr',
-            product_data: { name: 'NFC 評論板組 月租' },
-            unit_amount: 1990,
-            recurring: { interval: 'month' }
-          },
-          quantity: 1
-        }
-      ],
-      customer: user.stripeCustomerId || undefined,
-      success_url: `${getRequestURL(event).origin}/dashboard`,
-      cancel_url: `${getRequestURL(event).origin}/`
-    })
-    if (session.subscription) {
-      await prisma.user.update({
-        where: { id: user.id },
-        data: { subscriptionId: session.subscription as string }
-      })
-    }
-  } else {
-    session = await stripe.checkout.sessions.create({
-      mode: 'payment',
-      payment_method_types: ['card'],
-      line_items: [
-        {
-          price_data: {
-            currency: 'myr',
-            product_data: { name: 'NFC 評論板組' },
-            unit_amount: 19900
-          },
-          quantity: 1
-        }
-      ],
-      success_url: `${getRequestURL(event).origin}/dashboard`,
-      cancel_url: `${getRequestURL(event).origin}/`
+  if (session.subscription) {
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { subscriptionId: session.subscription as string }
     })
   }
 


### PR DESCRIPTION
## Summary
- 精簡 `create-checkout-session.post.ts` 僅使用訂閱模式
- 新增月租與一次性建置費兩筆 line item

## Testing
- `npm test` *(失敗：缺少 vitest 套件)*

------
https://chatgpt.com/codex/tasks/task_e_6874a892ba7083299f73515c2453022b